### PR TITLE
修复一个导致下载速度减慢的bug

### DIFF
--- a/src/idle-loader.ts
+++ b/src/idle-loader.ts
@@ -57,6 +57,8 @@ export class IdleLoader {
   }
 
   checkProcessingIndex() {
+    // Skip found Fetcher
+    let foundFetcherIndex = new Set<Number>();
     for (let i = 0; i < this.processingIndexList.length; i++) {
       let processingIndex = this.processingIndexList[i];
       const imf = this.queue[processingIndex];
@@ -74,7 +76,8 @@ export class IdleLoader {
       ) {
         const imf = this.queue[j];
         // find img fetcher that hasn't been fetching
-        if (!imf.lock && imf.stage === FetchState.URL) {
+        if (!imf.lock && imf.stage === FetchState.URL && !foundFetcherIndex.has(j)) {
+          foundFetcherIndex.add(j);
           this.processingIndexList[i] = j;
           found = true;
           break;


### PR DESCRIPTION
由于没有检测重复，这里会导致下载队列都是同一个 Fetcher，使得下载速度减慢
![QQ图片1](https://github.com/MapoMagpie/eh-view-enhance/assets/155665830/7a3d24e8-11ef-4a70-9435-245a0b4aa966)

修复后：
![QQ截图2](https://github.com/MapoMagpie/eh-view-enhance/assets/155665830/b8982ada-7734-46d7-9354-b7663248a2ba)
