### PR TITLE
fix : doule check if downloading before abort

### DIFF
--- a/src/download/downloader.ts
+++ b/src/download/downloader.ts
@@ -36,6 +36,7 @@ export class Downloader {
     this.downloaderPanelBTN = HTML.downloaderPanelBTN;
     this.downloadForceElement.addEventListener("click", () => this.download());
     this.downloadStartElement.addEventListener("click", () => this.start());
+    this.idleLoader.setIsDownloading( () => this.downloading);
     this.queue.subscribeOnDo(1, () => this.downloading);
     this.queue.subscribeOnFinishedReport(0, (_, queue) => {
       if (queue.isFinised()) {

--- a/src/idle-loader.ts
+++ b/src/idle-loader.ts
@@ -10,6 +10,7 @@ export class IdleLoader {
   restartId?: number;
   maxWaitMS: number;
   minWaitMS: number;
+  IsDownloading?: () => boolean;
   onFailedCallback?: () => void;
   autoLoad: boolean = false;
   constructor(queue: IMGFetcherQueue) {
@@ -27,6 +28,10 @@ export class IdleLoader {
       this.abort(index);
       return false;
     });
+  }
+
+  setIsDownloading(cb: ()=>boolean) {
+    this.IsDownloading = cb;
   }
 
   onFailed(cb: () => void) {
@@ -128,6 +133,11 @@ export class IdleLoader {
     // 中止空闲加载后，会在等待一段时间后再次重启空闲加载
     window.clearTimeout(this.restartId);
     this.restartId = window.setTimeout(() => {
+      if (this.IsDownloading && this.IsDownloading()){
+        // Double check if we are downloading
+        // In case we change to a Big image, and click Download button before conf.restartIdleLoader seconds
+        return;
+      }
       this.processingIndexList = [newIndex];
       this.checkProcessingIndex();
       this.start(this.lockVer);


### PR DESCRIPTION

subscribeOnDo 在已经downloading的情况下，可以屏蔽掉abort

但如果刚切换大图，此时计时器已经被注册了，在conf.restartIdleLoader秒内点了 download按钮

一开始下载队列是多个并发的，但计时器到期后，会强行abort，并设置为1个，导致下载速度变慢