### PR TITLE
fix: handled e621 html structure change

### DIFF
--- a/eh-view-enhance.user.js
+++ b/eh-view-enhance.user.js
@@ -3882,7 +3882,9 @@ Reporta problemas aquí: <a target='_blank' href='https://github.com/MapoMagpie/
     }
     queryList(doc) {
       transient.imgSrcCSP = true;
-      return Array.from(doc.querySelectorAll("#posts-container > article"));
+      const list = doc.querySelectorAll(".posts-container > article");
+      console.log("queryList", list);
+      return Array.from(list);
     }
     toImgNode(ele) {
       const src = ele.getAttribute("data-preview-url");

--- a/eh-view-enhance.user.js
+++ b/eh-view-enhance.user.js
@@ -3882,9 +3882,7 @@ Reporta problemas aquí: <a target='_blank' href='https://github.com/MapoMagpie/
     }
     queryList(doc) {
       transient.imgSrcCSP = true;
-      const list = doc.querySelectorAll(".posts-container > article");
-      console.log("queryList", list);
-      return Array.from(list);
+      return Array.from(doc.querySelectorAll(".posts-container > article"));
     }
     toImgNode(ele) {
       const src = ele.getAttribute("data-preview-url");

--- a/package-lock.json
+++ b/package-lock.json
@@ -772,9 +772,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/platform/danbooru.ts
+++ b/src/platform/danbooru.ts
@@ -440,7 +440,7 @@ export class E621Matcher extends DanbooruMatcher {
   }
   queryList(doc: Document): HTMLElement[] {
     transient.imgSrcCSP = true;
-    return Array.from(doc.querySelectorAll<HTMLElement>("#posts-container > article"));
+    return Array.from(doc.querySelectorAll<HTMLElement>(".posts-container > article"));
   }
   toImgNode(ele: HTMLElement): [ImageNode | null, string] {
     const src = ele.getAttribute("data-preview-url");


### PR DESCRIPTION
E621's page structure has been slightly changed. So image was not loaded at all. 

This change has been done.

```
      return Array.from(doc.querySelectorAll("#posts-container > article"));
```
```
      return Array.from(doc.querySelectorAll(".posts-container > article"));
```

