### PR TITLE
优化wnacg，页面数量较多时频繁访问导致触发CF

### DIFF
--- a/eh-view-enhance.user.js
+++ b/eh-view-enhance.user.js
@@ -7089,7 +7089,8 @@ before contentType: ${contentType}, after contentType: ${blob.type}
     }
     async fetchOriginMeta(node) {
       const url = node.originSrc ?? node.thumbnailSrc;
-      const title = node.title;
+      const ext = url.includes(".") ? url.split(".").pop() : "jpg";
+      const title = node.title.replace("[", "").replace("]", "") + "." + ext;
       return { url, title };
     }
     workURL() {

--- a/eh-view-enhance.user.js
+++ b/eh-view-enhance.user.js
@@ -3104,7 +3104,6 @@ Reporta problemas aquí: <a target='_blank' href='https://github.com/MapoMagpie/
     debouncer = new Debouncer();
     rect;
     tags;
-    imgIndex;
     constructor(thumbnailSrc, href, title, delaySRC, originSrc, wh) {
       this.thumbnailSrc = thumbnailSrc;
       this.href = href;
@@ -7083,9 +7082,7 @@ before contentType: ${contentType}, after contentType: ${blob.type}
       const result = [];
       for (let index = 0; index < list.length; index++) {
         const img = list[index];
-        let imgNode = new ImageNode(img.url, img.url, img.caption);
-        imgNode.originSrc = img.url;
-        imgNode.imgIndex = index;
+        let imgNode = new ImageNode("", img.url, img.caption, void 0, img.url);
         result.push(imgNode);
       }
       return result;
@@ -7115,26 +7112,41 @@ before contentType: ${contentType}, after contentType: ${blob.type}
       meta.tags = { "tags": tags, "description": description };
       return meta;
     }
-    requestGalleryImages(galleryURL) {
-      return new Promise((resolve, reject) => {
-        window.fetch(galleryURL).then((res) => res.text()).then((text) => {
-          let js = "";
-          for (let line of text.split("\n")) {
-            line = line.replace('document.writeln("', "");
-            line = line.replace('");', "");
-            if (line.includes("var imglist")) {
-              line = line.replace("var imglist = ", "");
-              line = line.replaceAll("fast_img_host+\\", "");
-              line = line.replaceAll("\\", "");
-              js += line;
-            }
-          }
-          var imglist = this.extractUrlsAndCaptions(js);
-          console.log(imglist);
-          resolve(imglist);
-        }).catch(reject);
-      });
+    async requestGalleryImages(galleryURL) {
+      const text = await window.fetch(galleryURL).then((res) => res.text());
+      let js = "";
+      for (let line of text.split("\n")) {
+        line = line.replace('document.writeln("', "");
+        line = line.replace('");', "");
+        if (line.includes("var imglist")) {
+          line = line.replace("var imglist = ", "");
+          line = line.replaceAll("fast_img_host+\\", "");
+          line = line.replaceAll("\\", "");
+          js += line;
+        }
+      }
+      return this.extractUrlsAndCaptions(js);
     }
+    /*
+    document.writeln("	<script type=\"text/javascript\"> ");
+    document.writeln("		var sns_sys_id = '';");
+    document.writeln("		var sns_view_point_token = '';");
+    document.writeln("		var hash = window.location.hash;");
+    document.writeln("		if(!hash){");
+    document.writeln("			hash = 0;");
+    document.writeln("		}else{");
+    document.writeln("			hash = parseInt(hash.replace(\"#\",\"\")) - 1;");
+    document.writeln("		}");
+    document.writeln("		var fast_img_host=\"\";");
+    document.writeln("		var imglist = [{ url: fast_img_host+\"//img5.qy0.ru/data/2940/25/001.jpg\", caption: \"[001]\"},{ url: fast_img_host+\"/themes/weitu/images/bg/shoucang.jpg\", caption: \"喜歡紳士漫畫的同學請加入收藏哦！\"}];");
+    document.writeln("");
+    document.writeln("		$(function(){");
+    document.writeln("			imgscroll.beLoad($(\"#img_list\"),imglist,hash);");
+    document.writeln("		});");
+    document.writeln("	
+    <\/script>
+    ");
+    */
     extractUrlsAndCaptions(inputStr) {
       const regex = /url:\s*"(.*?)",\s*caption:\s*"(.*?)"/gs;
       let match;

--- a/src/img-node.ts
+++ b/src/img-node.ts
@@ -75,6 +75,7 @@ export default class ImageNode {
   private debouncer: Debouncer = new Debouncer();
   rect?: Rect;
   tags: Set<Tag>;
+  imgIndex?: number;
   constructor(thumbnailSrc: string, href: string, title: string, delaySRC?: Promise<string>, originSrc?: string, wh?: { w: number, h: number }) {
     this.thumbnailSrc = thumbnailSrc;
     this.href = href;

--- a/src/img-node.ts
+++ b/src/img-node.ts
@@ -75,7 +75,6 @@ export default class ImageNode {
   private debouncer: Debouncer = new Debouncer();
   rect?: Rect;
   tags: Set<Tag>;
-  imgIndex?: number;
   constructor(thumbnailSrc: string, href: string, title: string, delaySRC?: Promise<string>, originSrc?: string, wh?: { w: number, h: number }) {
     this.thumbnailSrc = thumbnailSrc;
     this.href = href;

--- a/src/platform/wnacg.ts
+++ b/src/platform/wnacg.ts
@@ -2,52 +2,51 @@ import { GalleryMeta } from "../download/gallery-meta";
 import ImageNode from "../img-node";
 import { BaseMatcher, OriginMeta, Result } from "./platform";
 
-export class WnacgMatcher extends BaseMatcher<Document> {
+export class WnacgMatcher extends BaseMatcher< GalleryImage[]> {
   name(): string {
     return "绅士漫画"
   }
 
   meta?: GalleryMeta;
   baseURL?: string;
+  galleryURL?: string;
 
-  async *fetchPagesSource(): AsyncGenerator<Result<Document>> {
+  async *fetchPagesSource(): AsyncGenerator<Result<GalleryImage[]>> {
     const id = this.extractIDFromHref(window.location.href);
     if (!id) {
       throw new Error("Cannot find gallery ID");
     }
     this.baseURL = `${window.location.origin}/photos-index-page-1-aid-${id}.html`;
+    this.galleryURL = `${window.location.origin}/photos-gallery-aid-${id}.html`;
+
     let doc = await window.fetch(this.baseURL).then((res) => res.text()).then((text) => new DOMParser().parseFromString(text, "text/html"));
     this.meta = this.pasrseGalleryMeta(doc);
-    yield Result.ok(doc);
-    while (true) {
-      const next = doc.querySelector<HTMLAnchorElement>(".paginator > .next > a");
-      if (!next) break;
-      const url = next.href;
-      doc = await window.fetch(url).then((res) => res.text()).then((text) => new DOMParser().parseFromString(text, "text/html"));
-      yield Result.ok(doc);
-    }
+
+    let galleryImageList = await this.requestGalleryImages(this.galleryURL);
+    yield Result.ok(galleryImageList);
+
   }
 
-  async parseImgNodes(doc: Document): Promise<ImageNode[]> {
+  async parseImgNodes(list: GalleryImage[]): Promise<ImageNode[]> {
+
     const result: ImageNode[] = [];
-    const list = Array.from(doc.querySelectorAll(".grid > .gallary_wrap > .cc > li"));
-    for (const li of list) {
-      const anchor = li.querySelector<HTMLAnchorElement>(".pic_box > a");
-      if (!anchor) continue;
-      const img = anchor.querySelector<HTMLImageElement>("img");
-      if (!img) continue;
-      const title = li.querySelector(".title > .name")?.textContent || "unknown";
-      result.push(new ImageNode(img.src, anchor.href, title));
+
+    for (let index = 0; index < list.length; index++) {
+      const img = list[index];
+
+      let imgNode = new ImageNode(img.url, img.url, img.caption);
+      imgNode.originSrc = img.url;
+      imgNode.imgIndex = index;
+
+      result.push(imgNode);
     }
     return result;
   }
 
   async fetchOriginMeta(node: ImageNode): Promise<OriginMeta> {
-    const doc = await window.fetch(node.href).then((res) => res.text()).then((text) => new DOMParser().parseFromString(text, "text/html"));
-    const img = doc.querySelector<HTMLImageElement>("#picarea")
-    if (!img) throw new Error(`Cannot find #picarea from ${node.href}`);
-    const url = img.src;
-    const title = url.split("/").pop();
+    
+    const url = node.originSrc ?? node.thumbnailSrc;
+    const title = node.title;
     return { url, title }
   }
 
@@ -75,4 +74,76 @@ export class WnacgMatcher extends BaseMatcher<Document> {
     return meta;
   }
 
+  private requestGalleryImages(galleryURL: string): Promise<GalleryImage[]> {
+    return new Promise<GalleryImage[]>((resolve, reject) => {
+      window.fetch(galleryURL)
+        .then((res) => res.text())
+        .then((text) => {
+          /*
+document.writeln("	<script type=\"text/javascript\">
+    ");
+document.writeln("		var sns_sys_id = '';");
+document.writeln("		var sns_view_point_token = '';");
+document.writeln("		var hash = window.location.hash;");
+document.writeln("		if(!hash){");
+document.writeln("			hash = 0;");
+document.writeln("		}else{");
+document.writeln("			hash = parseInt(hash.replace(\"#\",\"\")) - 1;");
+document.writeln("		}");
+document.writeln("		var fast_img_host=\"\";");
+document.writeln("		var imglist = [{ url: fast_img_host+\"//img5.qy0.ru/data/2940/25/001.jpg\", caption: \"[001]\"},{ url: fast_img_host+\"/themes/weitu/images/bg/shoucang.jpg\", caption: \"喜歡紳士漫畫的同學請加入收藏哦！\"}];");
+document.writeln("");
+document.writeln("		$(function(){");
+document.writeln("			imgscroll.beLoad($(\"#img_list\"),imglist,hash);");
+document.writeln("		});");
+document.writeln("	
+</script>
+");
+*/
+          let js = "";
+          for (let line of text.split("\n")) {
+            line = line.replace("document.writeln(\"", "");
+            line = line.replace("\");", "");
+            if (line.includes("var imglist")) {
+              line = line.replace("var imglist = ", "");
+              line = line.replaceAll("fast_img_host+\\", "");
+              line = line.replaceAll("\\", "");
+              js += line;
+            }
+          }
+          var imglist = this.extractUrlsAndCaptions(js);
+          console.log(imglist);
+          resolve(imglist);
+        }).catch(reject);
+    })
+  }
+
+
+  private extractUrlsAndCaptions(inputStr: string) {
+    const regex = /url:\s*"(.*?)",\s*caption:\s*"(.*?)"/gs;
+    let match;
+    const results = [];
+
+    while ((match = regex.exec(inputStr)) !== null) {
+      results.push({ url: match[1], caption: match[2] });
+    }
+
+    if (results.length > 0) {
+      if (results[results.length - 1].caption.includes("加入收藏")) {
+        results.pop();
+      }
+    }
+
+    return results;
+  }
+
+}
+
+class GalleryImage {
+  url: string;
+  caption: string;
+  constructor(url: string, caption: string) {
+    this.url = url;
+    this.caption = caption;
+  }
 }

--- a/src/platform/wnacg.ts
+++ b/src/platform/wnacg.ts
@@ -41,7 +41,8 @@ export class WnacgMatcher extends BaseMatcher<GalleryImage[]> {
 
   async fetchOriginMeta(node: ImageNode): Promise<OriginMeta> {
     const url = node.originSrc ?? node.thumbnailSrc;
-    const title = node.title;
+    const ext = url.includes(".") ? url.split(".").pop() : "jpg";
+    const title = node.title.replace("[", "").replace("]", "") + "." + ext;
     return { url, title }
   }
 

--- a/src/platform/wnacg.ts
+++ b/src/platform/wnacg.ts
@@ -2,7 +2,7 @@ import { GalleryMeta } from "../download/gallery-meta";
 import ImageNode from "../img-node";
 import { BaseMatcher, OriginMeta, Result } from "./platform";
 
-export class WnacgMatcher extends BaseMatcher< GalleryImage[]> {
+export class WnacgMatcher extends BaseMatcher<GalleryImage[]> {
   name(): string {
     return "绅士漫画"
   }
@@ -33,18 +33,13 @@ export class WnacgMatcher extends BaseMatcher< GalleryImage[]> {
 
     for (let index = 0; index < list.length; index++) {
       const img = list[index];
-
-      let imgNode = new ImageNode(img.url, img.url, img.caption);
-      imgNode.originSrc = img.url;
-      imgNode.imgIndex = index;
-
+      let imgNode = new ImageNode("", img.url, img.caption, undefined, img.url);
       result.push(imgNode);
     }
     return result;
   }
 
   async fetchOriginMeta(node: ImageNode): Promise<OriginMeta> {
-    
     const url = node.originSrc ?? node.thumbnailSrc;
     const title = node.title;
     return { url, title }
@@ -74,50 +69,42 @@ export class WnacgMatcher extends BaseMatcher< GalleryImage[]> {
     return meta;
   }
 
-  private requestGalleryImages(galleryURL: string): Promise<GalleryImage[]> {
-    return new Promise<GalleryImage[]>((resolve, reject) => {
-      window.fetch(galleryURL)
-        .then((res) => res.text())
-        .then((text) => {
-          /*
-document.writeln("	<script type=\"text/javascript\">
-    ");
-document.writeln("		var sns_sys_id = '';");
-document.writeln("		var sns_view_point_token = '';");
-document.writeln("		var hash = window.location.hash;");
-document.writeln("		if(!hash){");
-document.writeln("			hash = 0;");
-document.writeln("		}else{");
-document.writeln("			hash = parseInt(hash.replace(\"#\",\"\")) - 1;");
-document.writeln("		}");
-document.writeln("		var fast_img_host=\"\";");
-document.writeln("		var imglist = [{ url: fast_img_host+\"//img5.qy0.ru/data/2940/25/001.jpg\", caption: \"[001]\"},{ url: fast_img_host+\"/themes/weitu/images/bg/shoucang.jpg\", caption: \"喜歡紳士漫畫的同學請加入收藏哦！\"}];");
-document.writeln("");
-document.writeln("		$(function(){");
-document.writeln("			imgscroll.beLoad($(\"#img_list\"),imglist,hash);");
-document.writeln("		});");
-document.writeln("	
-</script>
-");
-*/
-          let js = "";
-          for (let line of text.split("\n")) {
-            line = line.replace("document.writeln(\"", "");
-            line = line.replace("\");", "");
-            if (line.includes("var imglist")) {
-              line = line.replace("var imglist = ", "");
-              line = line.replaceAll("fast_img_host+\\", "");
-              line = line.replaceAll("\\", "");
-              js += line;
-            }
-          }
-          var imglist = this.extractUrlsAndCaptions(js);
-          console.log(imglist);
-          resolve(imglist);
-        }).catch(reject);
-    })
+  private async requestGalleryImages(galleryURL: string): Promise<GalleryImage[]> {
+    const text = await window.fetch(galleryURL).then((res) => res.text());
+    let js = "";
+    for (let line of text.split("\n")) {
+      line = line.replace("document.writeln(\"", "");
+      line = line.replace("\");", "");
+      if (line.includes("var imglist")) {
+        line = line.replace("var imglist = ", "");
+        line = line.replaceAll("fast_img_host+\\", "");
+        line = line.replaceAll("\\", "");
+        js += line;
+      }
+    }
+    return this.extractUrlsAndCaptions(js);
   }
 
+  /*
+  document.writeln("	<script type=\"text/javascript\"> ");
+  document.writeln("		var sns_sys_id = '';");
+  document.writeln("		var sns_view_point_token = '';");
+  document.writeln("		var hash = window.location.hash;");
+  document.writeln("		if(!hash){");
+  document.writeln("			hash = 0;");
+  document.writeln("		}else{");
+  document.writeln("			hash = parseInt(hash.replace(\"#\",\"\")) - 1;");
+  document.writeln("		}");
+  document.writeln("		var fast_img_host=\"\";");
+  document.writeln("		var imglist = [{ url: fast_img_host+\"//img5.qy0.ru/data/2940/25/001.jpg\", caption: \"[001]\"},{ url: fast_img_host+\"/themes/weitu/images/bg/shoucang.jpg\", caption: \"喜歡紳士漫畫的同學請加入收藏哦！\"}];");
+  document.writeln("");
+  document.writeln("		$(function(){");
+  document.writeln("			imgscroll.beLoad($(\"#img_list\"),imglist,hash);");
+  document.writeln("		});");
+  document.writeln("	
+  </script>
+  ");
+  */
 
   private extractUrlsAndCaptions(inputStr: string) {
     const regex = /url:\s*"(.*?)",\s*caption:\s*"(.*?)"/gs;
@@ -139,11 +126,7 @@ document.writeln("
 
 }
 
-class GalleryImage {
+type GalleryImage = {
   url: string;
   caption: string;
-  constructor(url: string, caption: string) {
-    this.url = url;
-    this.caption = caption;
-  }
 }


### PR DESCRIPTION
通过下拉阅读页面的接口实现减少调用次数

列表页能获得预览图url，但是页码无法控制，单行本大概300页就会产生20+次的页面请求，有可能触发CF；
下拉阅读页接口返回的数据中无包含预览图url，只有原图url，而且对比过两个url无关联的标识，只有索引能作为关联标识，但如果去获取预览图又可能出现上述情况而触发CF，所以放弃了预览图