### PR TITLE
fix: e621.net;

### DIFF
--- a/eh-view-enhance.user.js
+++ b/eh-view-enhance.user.js
@@ -5006,7 +5006,7 @@ Reporta problemas aquí: <a target='_blank' href='https://github.com/MapoMagpie/
   class E621Matcher extends DanbooruMatcher {
     cache = /* @__PURE__ */ new Map();
     nextPage(doc) {
-      return doc.querySelector(".paginator #paginator-next")?.href ?? null;
+      return doc.querySelector(".pagination #paginator-next")?.href ?? null;
     }
     getOriginalURL() {
       throw new Error("Method not implemented.");
@@ -5029,10 +5029,11 @@ Reporta problemas aquí: <a target='_blank' href='https://github.com/MapoMagpie/
     toImgNode(ele) {
       const src = ele.getAttribute("data-preview-url");
       if (!src) return [null, ""];
-      const href = `${window.location.origin}/posts/${ele.getAttribute("data-id")}`;
+      const href = ele.getAttribute("data-file-url");
+      if (!href) return [null, ""];
       const tags = ele.getAttribute("data-tags");
       const id = ele.getAttribute("data-id");
-      const normal = ele.getAttribute("data-large-url");
+      const normal = ele.getAttribute("data-sample-url");
       const original = ele.getAttribute("data-file-url");
       const fileExt = ele.getAttribute("data-file-ext") || void 0;
       if (!normal || !original || !id) return [null, ""];

--- a/src/platform/danbooru.ts
+++ b/src/platform/danbooru.ts
@@ -425,7 +425,7 @@ export class GelBooruMatcher extends DanbooruMatcher {
 export class E621Matcher extends DanbooruMatcher {
   cache: Map<string, { normal: string, original: string, id: string, fileExt?: string }> = new Map();
   nextPage(doc: Document): string | null {
-    return doc.querySelector<HTMLAnchorElement>(".paginator #paginator-next")?.href ?? null;
+    return doc.querySelector<HTMLAnchorElement>(".pagination #paginator-next")?.href ?? null;
   }
   getOriginalURL(): string | null {
     throw new Error("Method not implemented.");
@@ -448,10 +448,11 @@ export class E621Matcher extends DanbooruMatcher {
   toImgNode(ele: HTMLElement): [ImageNode | null, string] {
     const src = ele.getAttribute("data-preview-url");
     if (!src) return [null, ""];
-    const href = `${window.location.origin}/posts/${ele.getAttribute("data-id")}`;
+    const href = ele.getAttribute("data-file-url");
+    if (!href) return [null, ""];
     const tags = ele.getAttribute("data-tags");
     const id = ele.getAttribute("data-id");
-    const normal = ele.getAttribute("data-large-url");
+    const normal = ele.getAttribute("data-sample-url");
     const original = ele.getAttribute("data-file-url");
     const fileExt = ele.getAttribute("data-file-ext") || undefined;
     if (!normal || !original || !id) return [null, ""];


### PR DESCRIPTION
e621.net recently had a [major site overhaul](https://e926.net/forum_topics/55175), resulting in breaking changes with the current `E621Matcher` in the plugin.

This PR fixes it.

I am not sure if `data-large-url` in the old site structure is equivalent to `data-sample-url` in the new site structure, but I swapped them anyway.

For the record, each image node on e621's posts page provides three file URLs:
- data-preview-url="https://static1.e621.net/data/preview/..."
- data-sample-url="https://static1.e621.net/data/sample/..."
- data-file-url="https://static1.e621.net/data/..."

`data-preview-url` gives you a small image for the "/posts" endpoint.
`data-sample-url` gives you a shrunk image, 850px for the smaller axis (horizontal or vertical).
`data-file-url` gives you the original image.

Please let me know if you have any questions.