### PR TITLE
fix e621 thumbnail middle click behaviour

### DIFF
--- a/eh-view-enhance.user.js
+++ b/eh-view-enhance.user.js
@@ -5044,8 +5044,8 @@ Reporta problemas aquí: <a target='_blank' href='https://github.com/MapoMagpie/
     getNormalURL() {
       throw new Error("Method not implemented.");
     }
-    extractIDFromHref() {
-      throw new Error("Method not implemented.");
+    extractIDFromHref(href) {
+      return href.match(/posts\/(\d+)/)?.[1];
     }
     getBlacklist(doc) {
       const content = doc.querySelector("meta[name='blacklisted-tags']")?.getAttribute("content");
@@ -5073,16 +5073,17 @@ Reporta problemas aquí: <a target='_blank' href='https://github.com/MapoMagpie/
       if (width && height) {
         wh = { w: parseInt(width), h: parseInt(height) };
       }
-      this.cache.set(href, { normal, original, id, fileExt });
-      return [new ImageNode(src, href, `${id}.jpg`, void 0, void 0, wh), tags || ""];
+      this.cache.set(id, { normal, original, id, fileExt });
+      return [new ImageNode(src, `/posts/${id}`, `${id}.jpg`, void 0, void 0, wh), tags || ""];
     }
     cachedOriginMeta(href) {
-      const cached = this.cache.get(href);
+      const id = this.extractIDFromHref(href);
+      const cached = this.cache.get(id);
       if (!cached) throw new Error("miss origin meta: " + href);
       if (["webm", "webp", "mp4"].includes(cached.fileExt ?? "bbb") || conf.fetchOriginal) {
-        return { url: cached.original, title: `${cached.id}.${cached.fileExt}` };
+        return { url: cached.original, title: `${id}.${cached.fileExt}` };
       }
-      return { url: cached.normal, title: `${cached.id}.${cached.normal.split(".").pop()}` };
+      return { url: cached.normal, title: `${id}.${cached.normal.split(".").pop()}` };
     }
     site() {
       return "e621";


### PR DESCRIPTION
for some reason middle-clicking thumbnails on e621 opens the direct link to the raw image instead of the image post (on all other websites it does the opposite), and it was getting frustrating, so this pr corrects that!

the changes also required an update to the caching function so the big image viewer wouldn't break