### PR TITLE
feat: add reading progress resume

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -115,6 +115,8 @@ export type Config = {
   magnifier: boolean,
   /** directly enter into big image view */
   autoEnterBig: boolean,
+  /** Save and restore the last reading position for each chapter. */
+  recordReadingProgress: boolean,
   /** Reading position recorded. A new chapter continuing from this position will be provided next time. */
   pixivRecordReading: boolean,
   /** the aritst's works order, ascend true means old first */
@@ -191,6 +193,7 @@ export function defaultConf(): Config {
     customStyle: "",
     magnifier: false,
     autoEnterBig: false,
+    recordReadingProgress: false,
     pixivRecordReading: false,
     pixivAscendWorks: false,
     pixivUgoiraMode: "ugoira",
@@ -382,6 +385,7 @@ export type ConfigBooleanType = "fetchOriginal"
   | "reverseMultipleImagesPost"
   | "magnifier"
   | "autoEnterBig"
+  | "recordReadingProgress"
   | "pixivRecordReading"
   | "pixivAscendWorks"
   | "hdThumbnails"
@@ -437,6 +441,7 @@ export const ConfigItems: ConfigItem[] = [
   { key: "autoOpen", typ: "boolean", gridColumnRange: [6, 11] },
   { key: "magnifier", typ: "boolean", gridColumnRange: [1, 6] },
   { key: "autoEnterBig", typ: "boolean", gridColumnRange: [6, 11] },
+  { key: "recordReadingProgress", typ: "boolean", gridColumnRange: [1, 11] },
   { key: "dragImageOut", typ: "boolean", gridColumnRange: [1, 6] },
   { key: "hdThumbnails", typ: "boolean", gridColumnRange: [6, 11] },
   { key: "smartScrolling", typ: "boolean", gridColumnRange: [1, 11] },

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -47,6 +47,7 @@ export interface Events {
   "pf-append-chapters": (url: string) => Promise<Chapter[]>;
   "pf-try-extend": () => void;
   "pf-retry-extend": () => void;
+  "pf-load-until": (chapterIndex: number, index: number, displayIndex?: number) => void;
   "pf-step-chapters": (oriented: Oriented) => void;
   "imf-on-finished": (index: number, success: boolean, imf: IMGFetcher) => void;
   "imf-on-click": (imf: IMGFetcher) => void;
@@ -74,4 +75,3 @@ export type EventID = keyof Events;
 
 const EBUS = new EventManager();
 export default EBUS;
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { sleep } from "./utils/sleep";
 import { evLog } from "./utils/ev-log";
 import { Filter } from "./filter";
 import { ContextMenu } from "./ui/context-menu";
+import { ReadingProgress } from "./reading-progress";
 
 // Dynamically import the modules under ./platform/matchers, in which ADAPTER.addSetup will be executed
 const modules = import.meta.glob('./platform/matchers/*.ts', { eager: true });
@@ -39,6 +40,7 @@ function setup(): DestoryFunc {
   const PH: PageHelper = new PageHelper(HTML, () => PF.chapters, () => DL.downloading);
   const BIFM: BigImageFrameManager = new BigImageFrameManager(HTML, (index) => PF.chapters[index]);
   const FVGM: FullViewGridManager = new FullViewGridManager(HTML, BIFM);
+  new ReadingProgress(() => PF.chapters);
 
   const events = initEvents(HTML, BIFM, FVGM, IFQ, IL, PH);
   addEventListeners(events, HTML, BIFM, DL, PH);

--- a/src/page-fetcher.ts
+++ b/src/page-fetcher.ts
@@ -71,6 +71,7 @@ export class PageFetcher {
     // triggered when scrolling
     EBUS.subscribe("pf-try-extend", () => debouncer.addEvent("APPEND-NEXT-PAGES", () => !this.queue.downloading?.() && this.appendNextPage(), 5));
     EBUS.subscribe("pf-retry-extend", () => !this.queue.downloading?.() && this.appendNextPage(true));
+    EBUS.subscribe("pf-load-until", (chapterIndex, index, displayIndex) => this.loadUntil(chapterIndex, index, displayIndex));
     EBUS.subscribe("pf-init", (cb) => this.init().then(cb));
     EBUS.subscribe("pf-append-chapters", (url) => this.appendNewChapters(url).then(() => this.chapters));
     EBUS.subscribe("pf-step-chapters", (oriented) => {
@@ -212,6 +213,21 @@ export class PageFetcher {
   private async appendPages(appendedCount: number) {
     while (true) {
       if (appendedCount + 60 < this.queue.length) break;
+      if (!await this.appendNextPage()) break;
+    }
+  }
+
+  private async loadUntil(chapterIndex: number, index: number, displayIndex: number = index) {
+    if (chapterIndex !== this.chapterIndex || this.queue.downloading?.()) return;
+    const chapter = this.chapters[chapterIndex];
+    let lastNotifiedAt = Date.now();
+    EBUS.emit("notify-message", "info", `Looking for saved page ${displayIndex + 1}...`, 2000);
+    while (!chapter.done && chapter.filteredQueue.length <= index) {
+      if (chapterIndex !== this.chapterIndex || this.abortb) break;
+      if (Date.now() - lastNotifiedAt > 3000) {
+        lastNotifiedAt = Date.now();
+        EBUS.emit("notify-message", "info", `Loaded ${chapter.filteredQueue.length} pages while looking for saved page ${displayIndex + 1}...`, 2000);
+      }
       if (!await this.appendNextPage()) break;
     }
   }

--- a/src/page-fetcher.ts
+++ b/src/page-fetcher.ts
@@ -52,7 +52,7 @@ export class PageFetcher {
   beforeInit?: () => void;
   afterInit?: () => void;
   nodeActionDesc: { icon: string; description: string, fun: Function }[] = [];
-  private appendPageLock: boolean = false;
+  private appendPagePromise?: Promise<boolean>;
   private abortb: boolean = false;
 
   constructor(queue: IMGFetcherQueue, matcher: Matcher<any>, filter: Filter) {
@@ -198,11 +198,7 @@ export class PageFetcher {
       return;
     }
     if (chapter.queue.length === 0) {
-      const first = await chapter.sourceIter.next();
-      if (first.value) {
-        if (first.value.error) throw first.value.error;
-        await this.appendImages(first.value.value, this.chapterIndex);
-      }
+      await this.appendNextPage();
       this.appendPages(this.queue.length);
     }
   }
@@ -233,10 +229,20 @@ export class PageFetcher {
   }
 
   async appendNextPage(force?: boolean): Promise<boolean> {
-    if (this.appendPageLock) return false;
+    if (this.appendPagePromise) {
+      return this.appendPagePromise;
+    }
+    this.appendPagePromise = this.appendNextPageLocked(force)
+      .finally(() => {
+        this.appendPagePromise = undefined;
+      });
+    return this.appendPagePromise;
+  }
+
+  private async appendNextPageLocked(force?: boolean): Promise<boolean> {
     try {
-      this.appendPageLock = true;
-      const chapter = this.chapters[this.chapterIndex];
+      const chapterIndex = this.chapterIndex;
+      const chapter = this.chapters[chapterIndex];
       if (force) chapter.done = false; // FIXME: reset the iter
       if (chapter.done || this.abortb) return false;
       // fetch next page data
@@ -247,15 +253,15 @@ export class PageFetcher {
       }
       // Parse the next page data to IMGFetcher[], then append to view and IMGFetcherQueue
       if (next.value?.value) {
-        return await this.appendImages(next.value.value, this.chapterIndex);
+        return await this.appendImages(next.value.value, chapterIndex);
       }
       // If chapter.sourceIter is done, call this.appendToView() to trigger the update of some view elements
       if (next.done) {
         chapter.done = true;
         if (next.value?.value) {
-          return await this.appendImages(next.value.value, this.chapterIndex);
+          return await this.appendImages(next.value.value, chapterIndex);
         } else {
-          this.appendToView(this.queue.length, [], this.chapterIndex, true);
+          this.appendToView(this.queue.length, [], chapterIndex, true);
           return false;
         }
       } else {
@@ -265,8 +271,6 @@ export class PageFetcher {
       evLog("error", "PageFetcher:appendNextPage error: ", error);
       this.onFailed?.(error);
       return false;
-    } finally {
-      this.appendPageLock = false;
     }
   }
 

--- a/src/reading-progress.ts
+++ b/src/reading-progress.ts
@@ -1,0 +1,93 @@
+import EBUS from "./event-bus";
+import { IMGFetcher } from "./img-fetcher";
+import { Chapter } from "./page-fetcher";
+import { ADAPTER } from "./platform/adapt";
+import { b64EncodeUnicode } from "./utils/random";
+
+type ReadingProgressRecord = {
+  chapterSource: string;
+  chapterTitle: string;
+  index: number;
+  nodeKey: string;
+  updatedAt: number;
+};
+
+const STORAGE_PREFIX = "ehvh_reading_progress_";
+const RESTORE_SCAN_AHEAD = 200;
+
+export class ReadingProgress {
+  private chapters: () => Chapter[];
+  private restoredChapters: Set<string> = new Set();
+
+  constructor(chapters: () => Chapter[]) {
+    this.chapters = chapters;
+
+    EBUS.subscribe("ifq-do", (index, imf) => this.save(index, imf));
+    EBUS.subscribe("pf-change-chapter", (index) => this.restore(index));
+    EBUS.subscribe("pf-on-appended", (_total, _nodes, chapterIndex) => this.restore(chapterIndex));
+  }
+
+  private enabled() {
+    return ADAPTER.conf.recordReadingProgress;
+  }
+
+  private key(chapter: Chapter) {
+    const matcherName = ADAPTER.matcher?.name ?? "unknown";
+    return STORAGE_PREFIX + b64EncodeUnicode(`${matcherName}\n${chapter.source}`).replaceAll(/[+=\/]/g, "-");
+  }
+
+  private nodeKey(imf: IMGFetcher) {
+    return imf.node.originSrc || imf.node.href || imf.node.thumbnailSrc || imf.node.title;
+  }
+
+  private save(index: number, imf: IMGFetcher) {
+    if (!this.enabled()) return;
+    const chapter = this.chapters()[imf.chapterIndex];
+    if (!chapter) return;
+    const record: ReadingProgressRecord = {
+      chapterSource: chapter.source,
+      chapterTitle: Array.isArray(chapter.title) ? chapter.title.join(" / ") : chapter.title,
+      index,
+      nodeKey: this.nodeKey(imf),
+      updatedAt: Date.now(),
+    };
+    window.localStorage.setItem(this.key(chapter), JSON.stringify(record));
+  }
+
+  private read(chapter: Chapter): ReadingProgressRecord | null {
+    const raw = window.localStorage.getItem(this.key(chapter));
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as ReadingProgressRecord;
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  private restore(chapterIndex: number) {
+    if (!this.enabled() || chapterIndex < 0) return;
+    const chapter = this.chapters()[chapterIndex];
+    if (!chapter || this.restoredChapters.has(this.key(chapter))) return;
+    const record = this.read(chapter);
+    if (!record) return;
+
+    const matchingIndex = chapter.filteredQueue.findIndex(imf => this.nodeKey(imf) === record.nodeKey);
+    const scanLimit = record.nodeKey ? record.index + RESTORE_SCAN_AHEAD : record.index;
+    if (matchingIndex < 0 && !chapter.done && chapter.filteredQueue.length <= scanLimit) {
+      EBUS.emit("pf-load-until", chapterIndex, scanLimit, record.index);
+      return;
+    }
+
+    const fallbackIndex = Math.min(record.index, Math.max(chapter.filteredQueue.length - 1, 0));
+    const targetIndex = matchingIndex >= 0 ? matchingIndex : fallbackIndex;
+    const target = chapter.filteredQueue[targetIndex];
+
+    if (target) {
+      this.restoredChapters.add(this.key(chapter));
+      EBUS.emit("imf-on-click", target);
+      EBUS.emit("notify-message", "info", `Resume from page ${target.index + 1}`, 1500);
+    } else if (!chapter.done) {
+      EBUS.emit("pf-load-until", chapterIndex, record.index, record.index);
+    }
+  }
+}

--- a/src/reading-progress.ts
+++ b/src/reading-progress.ts
@@ -9,20 +9,26 @@ type ReadingProgressRecord = {
   chapterTitle: string;
   index: number;
   nodeKey: string;
+  nodeKeyType?: NodeKeyType;
   updatedAt: number;
 };
 
 const STORAGE_PREFIX = "ehvh_reading_progress_";
-const RESTORE_SCAN_AHEAD = 200;
+const INDEX_MATCH_TOLERANCE = 20;
+const RESTORE_SAVE_SUPPRESSION_MS = 120000;
+type NodeKeyType = "originSrc" | "href" | "thumbnailSrc" | "title";
 
 export class ReadingProgress {
   private chapters: () => Chapter[];
   private restoredChapters: Set<string> = new Set();
+  private suppressSaveUntilByChapter: Map<number, number> = new Map();
+  private restoringChapters: Map<number, number> = new Map();
 
   constructor(chapters: () => Chapter[]) {
     this.chapters = chapters;
 
     EBUS.subscribe("ifq-do", (index, imf) => this.save(index, imf));
+    EBUS.subscribe("imf-on-finished", (index, success, imf) => this.upgradeSavedKey(index, success, imf));
     EBUS.subscribe("pf-change-chapter", (index) => this.restore(index));
     EBUS.subscribe("pf-on-appended", (_total, _nodes, chapterIndex) => this.restore(chapterIndex));
   }
@@ -36,21 +42,63 @@ export class ReadingProgress {
     return STORAGE_PREFIX + b64EncodeUnicode(`${matcherName}\n${chapter.source}`).replaceAll(/[+=\/]/g, "-");
   }
 
-  private nodeKey(imf: IMGFetcher) {
-    return imf.node.originSrc || imf.node.href || imf.node.thumbnailSrc || imf.node.title;
+  private nodeKeyInfo(imf: IMGFetcher): { key: string, type: NodeKeyType } {
+    if (imf.node.originSrc) return { key: imf.node.originSrc, type: "originSrc" };
+    if (imf.node.href) return { key: imf.node.href, type: "href" };
+    if (imf.node.thumbnailSrc) return { key: imf.node.thumbnailSrc, type: "thumbnailSrc" };
+    return { key: imf.node.title, type: "title" };
   }
 
-  private save(index: number, imf: IMGFetcher) {
+  private nodeKey(imf: IMGFetcher) {
+    return this.nodeKeyInfo(imf).key;
+  }
+
+  private closestMatchingIndex(chapter: Chapter, record: ReadingProgressRecord) {
+    let bestIndex = -1;
+    let bestDistance = Infinity;
+    chapter.filteredQueue.forEach((imf, index) => {
+      if (this.nodeKey(imf) !== record.nodeKey) return;
+      const distance = Math.abs(index - record.index);
+      if (distance < bestDistance) {
+        bestIndex = index;
+        bestDistance = distance;
+      }
+    });
+    return bestIndex;
+  }
+
+  private save(_index: number, imf: IMGFetcher) {
     if (!this.enabled()) return;
+    const suppressSaveUntil = this.suppressSaveUntilByChapter.get(imf.chapterIndex);
+    const restoringUntil = this.restoringChapters.get(imf.chapterIndex);
+    if ((suppressSaveUntil && Date.now() < suppressSaveUntil) || (restoringUntil && Date.now() < restoringUntil)) {
+      return;
+    }
+    this.suppressSaveUntilByChapter.delete(imf.chapterIndex);
+    this.restoringChapters.delete(imf.chapterIndex);
     const chapter = this.chapters()[imf.chapterIndex];
     if (!chapter) return;
+    const nodeKey = this.nodeKeyInfo(imf);
     const record: ReadingProgressRecord = {
       chapterSource: chapter.source,
       chapterTitle: Array.isArray(chapter.title) ? chapter.title.join(" / ") : chapter.title,
-      index,
-      nodeKey: this.nodeKey(imf),
+      index: imf.index,
+      nodeKey: nodeKey.key,
+      nodeKeyType: nodeKey.type,
       updatedAt: Date.now(),
     };
+    window.localStorage.setItem(this.key(chapter), JSON.stringify(record));
+  }
+
+  private upgradeSavedKey(index: number, success: boolean, imf: IMGFetcher) {
+    if (!this.enabled() || !success || !imf.node.originSrc) return;
+    const chapter = this.chapters()[imf.chapterIndex];
+    if (!chapter) return;
+    const record = this.read(chapter);
+    if (!record || record.index !== index) return;
+    record.nodeKey = imf.node.originSrc;
+    record.nodeKeyType = "originSrc";
+    record.updatedAt = Date.now();
     window.localStorage.setItem(this.key(chapter), JSON.stringify(record));
   }
 
@@ -70,24 +118,39 @@ export class ReadingProgress {
     if (!chapter || this.restoredChapters.has(this.key(chapter))) return;
     const record = this.read(chapter);
     if (!record) return;
+    this.restoringChapters.set(chapterIndex, Date.now() + RESTORE_SAVE_SUPPRESSION_MS);
 
-    const matchingIndex = chapter.filteredQueue.findIndex(imf => this.nodeKey(imf) === record.nodeKey);
-    const scanLimit = record.nodeKey ? record.index + RESTORE_SCAN_AHEAD : record.index;
-    if (matchingIndex < 0 && !chapter.done && chapter.filteredQueue.length <= scanLimit) {
+    const matchingIndex = this.closestMatchingIndex(chapter, record);
+    const matchingDistance = matchingIndex >= 0 ? Math.abs(matchingIndex - record.index) : Infinity;
+    const canTrustFarMatch = record.nodeKeyType === "originSrc";
+    const trustedMatchingIndex = canTrustFarMatch || matchingDistance <= INDEX_MATCH_TOLERANCE ? matchingIndex : -1;
+    const scanLimit = record.index;
+    if (!chapter.done && chapter.filteredQueue.length <= scanLimit) {
       EBUS.emit("pf-load-until", chapterIndex, scanLimit, record.index);
       return;
     }
 
     const fallbackIndex = Math.min(record.index, Math.max(chapter.filteredQueue.length - 1, 0));
-    const targetIndex = matchingIndex >= 0 ? matchingIndex : fallbackIndex;
+    const targetIndex = trustedMatchingIndex >= 0 ? trustedMatchingIndex : fallbackIndex;
     const target = chapter.filteredQueue[targetIndex];
 
     if (target) {
       this.restoredChapters.add(this.key(chapter));
-      EBUS.emit("imf-on-click", target);
-      EBUS.emit("notify-message", "info", `Resume from page ${target.index + 1}`, 1500);
+      this.suppressSaveUntilByChapter.set(chapterIndex, Date.now() + 2000);
+      window.setTimeout(() => {
+        this.suppressSaveUntilByChapter.delete(chapterIndex);
+        this.restoringChapters.delete(chapterIndex);
+      }, 2000);
+      window.setTimeout(() => {
+        window.requestAnimationFrame(() => {
+          EBUS.emit("imf-on-click", target);
+          EBUS.emit("notify-message", "info", `Resume from page ${target.index + 1}`, 1500);
+        });
+      }, 0);
     } else if (!chapter.done) {
       EBUS.emit("pf-load-until", chapterIndex, record.index, record.index);
+    } else {
+      this.restoringChapters.delete(chapterIndex);
     }
   }
 }

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -328,6 +328,18 @@ pero desactivará la lupa y la capacidad de arrastrar y mover imágenes.`,
     '이미지 뷰어가 열리면 즉시 큰 이미지 보기 모드로 전환됩니다.',
     'Entrar directamente en la vista de imagen grande cuando se haga clic en la entrada del script o se abra automáticamente'
   ],
+  recordReadingProgress: [
+    'Record Reading Progress',
+    '记录阅读进度',
+    '읽기 진행 상황 기록',
+    'Registrar progreso de lectura',
+  ],
+  recordReadingProgressTooltip: [
+    'Remember the last opened page for each chapter and resume from it when the viewer is opened again. If pages changed, the saved image URL is matched first, then the nearest available page is used.',
+    '记住每个章节最后打开的页面，并在再次打开阅读器时恢复。如果页面发生变化，会优先匹配已保存的图片地址，再使用最近的可用页。',
+    '각 챕터에서 마지막으로 연 페이지를 기억하고 뷰어를 다시 열 때 이어서 엽니다. 페이지가 변경된 경우 저장된 이미지 URL을 먼저 찾고, 없으면 가장 가까운 사용 가능한 페이지를 사용합니다.',
+    'Recuerda la última página abierta de cada capítulo y la reanuda al volver a abrir el visor. Si las páginas cambiaron, primero se busca la URL de imagen guardada y luego se usa la página disponible más cercana.',
+  ],
   hdThumbnails: [
     "HD Thumbnails",
     "高清缩略图",


### PR DESCRIPTION
 # ZH
  ## 摘要

  这个 PR 新增了一个可选的阅读进度恢复功能。

  启用后，Comic Looms 会记录每个章节最后打开的图片，并在下次再次打开该章节时尝试从该图片继续阅读。恢复时会优先匹配之前保存的图片标识；如果找不到完全相同的图片，则回退到保存的页码附近。

  ## 行为说明

  - 新增 `recordReadingProgress` 布尔配置项，默认关闭。
  - 在图片被打开时通过 `ifq-do` 记录阅读进度。
  - 按 matcher 名称和章节来源分别保存进度。
  - 保存内容包括：
    - 章节来源
    - 章节标题
    - 页码索引
    - 图片 / 节点标识
    - 更新时间
  - 在切换章节或章节内容继续加载后尝试恢复进度。
  - 如果保存的页码尚未加载，会通过 `PageFetcher` 继续加载，直到可以到达保存位置。
  - 恢复时优先使用保存的图片标识；如果匹配失败，则使用保存的页码或当前已加载范围内最接近的位置。

  ## 与 Pixiv 记录阅读位置的区别

  这个功能有意与现有的 Pixiv 专用 `pixivRecordReading` 选项保持独立。

  现有 Pixiv 功能会记录某个作者最后读到的作品，并在下次加载作者作品列表时，根据该位置生成“上次阅读之后”/“上次阅读之前”等章节。它更像是 Pixiv 作者作品列表的分段功能。

  本 PR 新增的是通用的阅读器级别恢复功能：重新打开同一个章节 / 图库时，可以回到上次打开的页面。

  ## 实现说明

  - 新增 `ReadingProgress`，作为一个较小的事件驱动模块。
  - 使用 `window.localStorage` 保存阅读进度，风格上与现有 Pixiv 阅读记录实现保持一致。
  - 新增 `pf-load-until` 事件，使恢复逻辑可以在目标页面尚未加载时请求继续加载章节内容。
  - 为新的配置项添加了 i18n 文案。

  ## 测试

  - 已运行 `npm run build`，构建通过。

  ## AI 使用披露

  本 PR 在 OpenAI Codex 的辅助下完成。提交前已在本地检查实现并运行构建测试。

---
 # ENG

  ## Summary

  This adds an opt-in reading progress resume feature for chapters.

  When enabled, Comic Looms records the last opened image for each chapter and attempts to resume from that image when the chapter is opened again. The restore logic first tries to match the previously saved image identity, then falls back to the nearest available page index if the exact image cannot be found.

  ## Behavior

  - Adds a new `recordReadingProgress` boolean config option, disabled by default.
  - Saves progress when an image fetcher is opened via `ifq-do`.
  - Stores progress per matcher and chapter source.
  - Records:
    - chapter source
    - chapter title
    - page index
    - image/node key
    - update timestamp
  - Restores on chapter change or when chapter items are appended.
  - If the saved page is not loaded yet, asks `PageFetcher` to load ahead until the saved position can be reached.
  - Uses the saved image key first, then falls back to the saved index or nearest available loaded page.

  ## Difference from Pixiv Record Reading

  This is intentionally separate from the existing Pixiv-specific `pixivRecordReading` option.

  The Pixiv option records the last-read artwork for an artist and uses that to create synthetic Pixiv artist chapters such as “before last reading” / “after last reading.” It is more of an artist-feed partitioning feature.

  This PR adds viewer-level resume behavior for regular chapters: reopening the same chapter/gallery can return the reader to the last opened page.

  ## Implementation Notes

  - Adds `ReadingProgress` as a small event-driven module.
 - Stores reading progress in `window.localStorage`, following the existing Pixiv reading-record implementation style.
  - Adds a `pf-load-until` event so restore can request more chapter items when the saved page has not been loaded yet.
  - Adds i18n strings for the new config option.

  ## Testing

  - Ran `npm run build` successfully.

  ## AI Assistance Disclosure

  This change was developed with assistance from OpenAI Codex. The implementation was reviewed locally before submission.

---

Human note: Let me know if you want anything changed, I'll happily make changes.